### PR TITLE
correct JSON-LD media type

### DIFF
--- a/packages/dataset/example/loadDataExample.ts
+++ b/packages/dataset/example/loadDataExample.ts
@@ -34,7 +34,7 @@ async function run(): Promise<void> {
   const jsonLdDataset = await serializedToDataset(JSON.stringify(jsonLdData), {
     baseIRI:
       "https://jackson.solidcommunity.net/IndividualChats/jackson.solidcommunity.net/index.ttl#",
-    format: "application/json-ld",
+    format: "application/ld+json",
   });
   // Returns true because the input data describes the same triple.
   console.log(turtleDataset.equals(jsonLdDataset));

--- a/packages/dataset/test/createExtendedDatasetFromSerializedInput.test.ts
+++ b/packages/dataset/test/createExtendedDatasetFromSerializedInput.test.ts
@@ -12,7 +12,7 @@ describe("createExtendedDatasetFromSerializedInput", () => {
 
   it.skip("creates a dataset with json-ld", async () => {
     const dataset = await serializedToDataset(JSON.stringify(jsonLdData), {
-      format: "application/json-ld",
+      format: "application/ld+json",
     });
     expect(dataset.size).toBe(9);
   });
@@ -26,7 +26,7 @@ describe("createExtendedDatasetFromSerializedInput", () => {
 
   it.skip("Should error when given invalid JSON", async () => {
     await expect(
-      serializedToDataset('{ bad" json', { format: "application/json-ld" }),
+      serializedToDataset('{ bad" json', { format: "application/ld+json" }),
     ).rejects.toThrow("Unexpected token b in JSON at position 2");
   });
 });

--- a/packages/ldo/src/parseRdf.ts
+++ b/packages/ldo/src/parseRdf.ts
@@ -47,7 +47,7 @@ export async function parseRdf(
       ldoDatasetFactory,
       JSON.stringify(data),
       {
-        format: "application/json-ld",
+        format: "application/ld+json",
       },
     );
   }

--- a/packages/rdf-utils/src/serializedToQuads.ts
+++ b/packages/rdf-utils/src/serializedToQuads.ts
@@ -9,7 +9,7 @@ export async function serializedToQuads(
   options?: ParserOptions,
 ): Promise<Quad[]> {
   // JSON-LD Parsing
-  if (options && options.format === "application/json-ld") {
+  if (options && options.format === "application/ld+json") {
     throw new Error("Not Implemented");
     // return new Promise((resolve, reject) => {
     //   JSON.parse(data);

--- a/packages/subscribable-dataset/Readme.md
+++ b/packages/subscribable-dataset/Readme.md
@@ -86,7 +86,7 @@ async function run(): Promise<void> {
     {
       baseIRI:
         "https://jackson.solidcommunity.net/IndividualChats/jackson.solidcommunity.net/index.ttl#",
-      format: "application/json-ld",
+      format: "application/ld+json",
     }
   );
   // Returns true because the input data describes the same triple.

--- a/packages/subscribable-dataset/test/createSubscribableDatasetFromSerializedInput.test.ts
+++ b/packages/subscribable-dataset/test/createSubscribableDatasetFromSerializedInput.test.ts
@@ -11,7 +11,7 @@ describe("createExtendedDatasetFromSerializedInput", () => {
     const dataset = await serializedToSubscribableDataset(
       JSON.stringify(jsonLdData),
       {
-        format: "application/json-ld",
+        format: "application/ld+json",
       },
     );
     expect(dataset.size).toBe(9);


### PR DESCRIPTION
Tests are failing inside of `@inrupt/solid-client-authn-core`, but it is unrelated to my changes.