### PR TITLE
Update parseRdf.ts

### DIFF
--- a/packages/ldo/src/parseRdf.ts
+++ b/packages/ldo/src/parseRdf.ts
@@ -24,7 +24,7 @@ import type { LdoDataset } from "./LdoDataset";
  * import { parseRdf } from "ldo";
  *
  * const rawTurtle = "...";
- * const ldoDataset = parseRdf(rawTurtle, { baseIRI: "https://example.com/" });
+ * const ldoDataset = await parseRdf(rawTurtle, { baseIRI: "https://example.com/" });
  * ```
  */
 export async function parseRdf(


### PR DESCRIPTION
I think this example is missing an await call. `parseRdf` returns a promise, but the name of the variable `ldoDataset` suggests that the promise is already unwrapped. 