### PR TITLE
Updating link header type in createDataResource (when creating container) from Container to BasicContainer

### DIFF
--- a/packages/solid/src/requester/requests/createDataResource.ts
+++ b/packages/solid/src/requester/requests/createDataResource.ts
@@ -216,7 +216,7 @@ export async function createDataResource(
       slug: getSlug(uri),
     };
     if (isContainerUri(uri)) {
-      headers.link = '<http://www.w3.org/ns/ldp#Container>; rel="type"';
+      headers.link = '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"';
     }
     const response = await fetch(parentUri, {
       method: "post",


### PR DESCRIPTION
The createDataResource function (which is called by the createIfAbsent method of a container), makes a POST request with a link header, which uses type `ldp#Container` (if the URI argument ends with a slash--otherwise it should create an RDF resource).

This works on solidweb.me, but doesn't work with solidcommunity.net (and possibly other pod providers using different server implementations), because it expects a container to be of type ldp#BasicContainer, and it creates an RDF resource (a ttl file) instead of a container. 

In the unofficial Solid protocol, https://solidproject.org/TR/protocol#resource-containment, it says, "The representation and behaviour of containers in Solid corresponds to LDP Basic Container and MUST be supported by server." 

So, apparently, using the Container type might work with some implementations, but the BasicContainer type should work with all servers (if they follow the unofficial protocol). I tested it, and this change does work for creating containers on both solidweb.me and solidcommunity.net.