### PR TITLE
Fix typo

### DIFF
--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -14,7 +14,7 @@ interface BuildOptions {
 }
 
 export async function build(options: BuildOptions) {
-  const load = loading("Peparing Environment");
+  const load = loading("Preparing Environment");
   load.start();
   // Prepare new folder by clearing/and/or creating it
   if (fs.existsSync(options.output)) {


### PR DESCRIPTION
First message when running `ldo build`: `Peparing` => `Preparing`

Feel free to close if PR too insignificant. :D