### PR TITLE
Feat: Keep comments on transpile

### DIFF
--- a/packages/connected/README.md
+++ b/packages/connected/README.md
@@ -63,7 +63,7 @@ async function main() {
    * ===========================================================================
    */
   const connectedLdoDataset = createConnectedLdoDataset([
-    solidConncetedPlugin,
+    solidConnectedPlugin,
     nextGraphConnectedPlugin
   ]);
   // Set context to be able to make authenticated requests

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "noImplicitAny": false,
-    "removeComments": true,
+    "removeComments": false,
     "lib": ["ES2021"],
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Currently, the jsdoc comments are not copied upon transpilation to js and to the d.ts files.
This prevents me from seeing the jsdoc comments in my IDE.

The PR sets `removeComments` in the `tsconfig.base.json` to false.

Also, I fixed a typo.