### PR TITLE
fix(cli): import types with type keyword in templates

### DIFF
--- a/packages/cli/src/templates/context.ejs
+++ b/packages/cli/src/templates/context.ejs
@@ -1,4 +1,4 @@
-import { LdoJsonldContext } from "@ldo/ldo";
+import type { LdoJsonldContext } from "@ldo/ldo";
 
 /**
  * =============================================================================

--- a/packages/cli/src/templates/schema.ejs
+++ b/packages/cli/src/templates/schema.ejs
@@ -1,4 +1,4 @@
-import { Schema } from "shexj";
+import type { Schema } from "shexj";
 
 /**
  * =============================================================================

--- a/packages/cli/src/templates/shapeTypes.ejs
+++ b/packages/cli/src/templates/shapeTypes.ejs
@@ -1,7 +1,7 @@
-import { ShapeType } from "@ldo/ldo";
+import type { ShapeType } from "@ldo/ldo";
 import { <%- fileName %>Schema } from "./<%- fileName %>.schema";
 import { <%- fileName %>Context } from "./<%- fileName %>.context";
-import {
+import type {
 <% typings.forEach((typing) => { -%>
   <%- typing.dts.name %>,
 <% }); -%>} from "./<%- fileName %>.typings";

--- a/packages/cli/src/templates/typings.ejs
+++ b/packages/cli/src/templates/typings.ejs
@@ -1,4 +1,4 @@
-import { LdoJsonldContext, LdSet } from "@ldo/ldo"; 
+import type { LdoJsonldContext, LdSet } from "@ldo/ldo";
 
 /**
  * =============================================================================


### PR DESCRIPTION
_I just hit this and it was a straightforward fix, so here it goes:_

This silences TypeScript error when `"verbatimModuleSyntax": true` in target project:

> '[...]' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled. ts(1484)

Fixes #72
