### PR TITLE
fix(connected-solid): use correct link header to create a container

### DIFF
--- a/packages/connected-solid/src/requester/requests/createDataResource.ts
+++ b/packages/connected-solid/src/requester/requests/createDataResource.ts
@@ -172,7 +172,7 @@ export async function createDataResource(
       slug: getSlug(resource.uri),
     };
     if (resource.type === "SolidContainer") {
-      headers.link = '<http://www.w3.org/ns/ldp#Container>; rel="type"';
+      headers.link = '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"';
     }
     const response = await fetch(parentUri, {
       method: "post",

--- a/packages/connected-solid/test/Integration.test.ts
+++ b/packages/connected-solid/test/Integration.test.ts
@@ -966,6 +966,13 @@ describe("Integration", () => {
           .children()
           .some((child) => child.uri === SAMPLE_CONTAINER_URI),
       ).toBe(true);
+      const postRequest = s.fetchMock.mock.calls.find(
+        (call) => call[1]?.method?.toLowerCase() === "post",
+      );
+      expect(postRequest?.[1]?.headers).toHaveProperty(
+        "link",
+        '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"',
+      );
     });
 
     it("returns an error if creating a container", async () => {


### PR DESCRIPTION
Value of link header `rel="type"` for creating a new container is now `ldp:BasicContainer`. This is more in line with [Solid specification of LDP containers](https://solidproject.org/TR/protocol#server-basic-container) than previous value `ldp:Container`.

See also https://github.com/o-development/ldo/issues/55#issuecomment-3757466153

Fixes #55