### PR TITLE
Use response.url as base URL of resource

### DIFF
--- a/packages/connected-solid/src/requester/requests/readResource.ts
+++ b/packages/connected-solid/src/requester/requests/readResource.ts
@@ -86,7 +86,7 @@ export async function readResource(
           undefined,
           undefined,
           undefined,
-          namedNode(resource.uri),
+          namedNode(response.url),
         );
       }
 
@@ -102,7 +102,7 @@ export async function readResource(
 
     // Add this resource to the container
     if (options?.dataset) {
-      addResourceRdfToContainer(resource.uri, options.dataset);
+      addResourceRdfToContainer(response.url, options.dataset);
     }
 
     const contentType = response.headers.get("content-type");
@@ -122,7 +122,7 @@ export async function readResource(
         const result = await addRawTurtleToDataset(
           rawTurtle,
           options.dataset,
-          resource.uri,
+          response.url,
         );
         if (result)
           return new NoncompliantPodError(resource, result.message) as

--- a/packages/connected-solid/test/Integration.test.ts
+++ b/packages/connected-solid/test/Integration.test.ts
@@ -111,6 +111,15 @@ const SAMPLE_PROFILE_TTL = `
 <${SAMPLE_PROFILE_URI}> pim:storage <https://example.com/A/>, <https://example.com/B/> .
 `;
 
+const REDIRECT_RESOURCE_SOURCE_URI =
+  `https://source.local/profile` as SolidLeafUri;
+const REDIRECT_RESOURCE_TARGET_URI =
+  `https://target.local/profile` as SolidLeafUri;
+const REDIRECT_RESOURCE_TTL = `
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+<#me> a foaf:Person.
+`;
+
 const resourceInfo: ResourceInfo = {
   slug: TEST_CONTAINER_SLUG,
   isContainer: true,
@@ -202,6 +211,18 @@ async function testRequestLoads<ReturnVal>(
     })(),
   ]);
   return returnVal;
+}
+
+class MockResponse extends Response {
+  constructor(
+    body?: BodyInit | null,
+    init?: ResponseInit & { url?: string; redirected?: boolean },
+  ) {
+    super(body, init);
+    if (init?.url) Object.defineProperty(this, "url", { value: init.url });
+    if (init?.redirected)
+      Object.defineProperty(this, "redirected", { value: init.redirected });
+  }
 }
 
 describe("Integration", () => {
@@ -358,7 +379,11 @@ describe("Integration", () => {
 
     it("Returns a NoncompliantPod error when no content type is returned", async () => {
       s.fetchMock.mockResolvedValueOnce(
-        new Response(undefined, { status: 200, headers: {} }),
+        new MockResponse(undefined, {
+          status: 200,
+          headers: {},
+          url: SAMPLE2_DATA_URI,
+        }),
       );
       const resource = solidLdoDataset.getResource(SAMPLE2_DATA_URI);
       const result = await testRequestLoads(() => resource.read(), resource, {
@@ -376,9 +401,10 @@ describe("Integration", () => {
 
     it("Returns a NoncompliantPod error if invalid turtle is provided", async () => {
       s.fetchMock.mockResolvedValueOnce(
-        new Response("Error", {
+        new MockResponse("Error", {
           status: 200,
           headers: new Headers({ "content-type": "text/turtle" }),
+          url: SAMPLE2_DATA_URI,
         }),
       );
       const resource = solidLdoDataset.getResource(SAMPLE2_DATA_URI);
@@ -397,9 +423,10 @@ describe("Integration", () => {
 
     it("Parses Turtle even when the content type contains parameters", async () => {
       s.fetchMock.mockResolvedValueOnce(
-        new Response(SPIDER_MAN_TTL, {
+        new MockResponse(SPIDER_MAN_TTL, {
           status: 200,
           headers: new Headers({ "content-type": "text/turtle;charset=utf-8" }),
+          url: SAMPLE_DATA_URI,
         }),
       );
       const resource = solidLdoDataset.getResource(SAMPLE_DATA_URI);
@@ -429,9 +456,10 @@ describe("Integration", () => {
 
     it("Does not return an error if there is no link header for a container request", async () => {
       s.fetchMock.mockResolvedValueOnce(
-        new Response(TEST_CONTAINER_TTL, {
+        new MockResponse(TEST_CONTAINER_TTL, {
           status: 200,
           headers: new Headers({ "content-type": "text/turtle" }),
+          url: TEST_CONTAINER_URI,
         }),
       );
       const resource = solidLdoDataset.getResource(TEST_CONTAINER_URI);
@@ -476,6 +504,30 @@ describe("Integration", () => {
       expect(s.fetchMock).toHaveBeenCalledTimes(3);
       expect(result.type).toBe("dataReadSuccess");
       expect(result1.type).toBe("dataReadSuccess");
+    });
+
+    it("reads a redirected resource using base url of the final resource", async () => {
+      s.fetchMock.mockResolvedValueOnce(
+        new MockResponse(REDIRECT_RESOURCE_TTL, {
+          status: 200,
+          headers: { "content-type": "text/turtle" },
+          url: REDIRECT_RESOURCE_TARGET_URI,
+          redirected: true,
+        }),
+      );
+
+      const resource = solidLdoDataset.getResource(
+        REDIRECT_RESOURCE_SOURCE_URI,
+      );
+      const result = await resource.read();
+      expect(result.type).toBe("dataReadSuccess");
+      expect(
+        solidLdoDataset.match(
+          namedNode(`${REDIRECT_RESOURCE_TARGET_URI}#me`),
+          namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+          namedNode("http://xmlns.com/foaf/0.1/Person"),
+        ).size,
+      ).toBe(1);
     });
   });
 


### PR DESCRIPTION
When doing a fetch in connected-solid, the response.url is used as base URL in turtle parser. It is also used as graph of quads.

Using response.url for graph part of quads may be controversial. I decided to go with it because final redirect URL is less ambiguous than its possibly multiple starting points. I can change that back to resource.uri if desirable.

package-lock seemed outdated, so I included up-to-date version.

Fixes #41