### PR TITLE
[connected-solid] Get root container from storage description resource

### DIFF
--- a/packages/connected-solid/src/requester/requests/getStorageDescription.ts
+++ b/packages/connected-solid/src/requester/requests/getStorageDescription.ts
@@ -1,19 +1,14 @@
 import { UnexpectedResourceError } from "@ldo/connected";
-import { namedNode } from "@ldo/rdf-utils";
 import { parse as parseLinkHeader } from "http-link-header";
-import type { SolidContainerUri, SolidLeafUri } from "../../types";
+import type { SolidLeafUri } from "../../types";
 import { guaranteeFetch } from "../../util/guaranteeFetch";
-import { rawTurtleToDataset } from "../../util/rdfUtils";
 import {
   HttpErrorResult,
   type HttpErrorResultType,
   NotFoundHttpError,
 } from "../results/error/HttpErrorResult";
 import { NoncompliantPodError } from "../results/error/NoncompliantPodError";
-import {
-  GetRootContainerFromStorageDescriptionSuccess,
-  GetStorageDescriptionUriSuccess,
-} from "../results/success/StorageDescriptionSuccess";
+import { GetStorageDescriptionUriSuccess } from "../results/success/StorageDescriptionSuccess";
 import type { BasicRequestOptions } from "./requestOptions";
 import type { SolidContainer } from "../../resources/SolidContainer.js";
 import type { SolidLeaf } from "../../resources/SolidLeaf.js";
@@ -81,81 +76,6 @@ export async function getStorageDescriptionUri(
     return new GetStorageDescriptionUriSuccess(
       resource,
       storageDescriptionLinks[0].uri as SolidLeafUri,
-    );
-  } catch (e) {
-    return UnexpectedResourceError.fromThrown(resource, e);
-  }
-}
-
-export type GetRootContainerFromStorageDescriptionError<
-  ResourceType extends SolidContainer | SolidLeaf,
-> =
-  | HttpErrorResultType<ResourceType>
-  | NoncompliantPodError<ResourceType>
-  | UnexpectedResourceError<ResourceType>;
-export type GetRootContainerFromStorageDescriptionResult<
-  ResourceType extends SolidContainer | SolidLeaf,
-> =
-  | GetRootContainerFromStorageDescriptionSuccess
-  | GetRootContainerFromStorageDescriptionError<ResourceType>;
-
-/**
- * Fetches storage description by its URI, and extracts root container from it
- * @param storageDescriptionUri - URI of storage description
- * @param resource - The resource that initiated the root container discovery
- * @param options - Options object with (authenticated) fetch function
- *
- * @returns GetRootContainerFromStorageDescriptionResult
- *
- * https://solidproject.org/TR/protocol#storage-description-rdf-type
- */
-export async function getRootContainerByStorageDescriptionUri(
-  storageDescriptionUri: SolidLeafUri,
-  resource: SolidLeaf | SolidContainer,
-  options?: BasicRequestOptions,
-): Promise<
-  GetRootContainerFromStorageDescriptionResult<SolidLeaf | SolidContainer>
-> {
-  try {
-    /**
-     * @TODO
-     * LDO could be used to fetch and/or process storage description resource
-     * Storage description is shared among pod resources. This dataset could be cached. (Where?)
-     * For fetching and caching, we would need a dataset. Could we use the resource's own dataset, or would it get polluted with this meta stuff?
-     */
-    const fetch = guaranteeFetch(options?.fetch);
-    const response = await fetch(storageDescriptionUri);
-    const errorResult = HttpErrorResult.checkResponse(resource, response);
-    if (errorResult) return errorResult;
-
-    if (response.status === 404) {
-      return new NoncompliantPodError(
-        resource,
-        "Storage description resource has not been found.",
-      );
-    }
-
-    const rawTurtle = await response.text();
-    const rawTurtleResult = await rawTurtleToDataset(rawTurtle, response.url);
-    if (rawTurtleResult instanceof Error)
-      return new NoncompliantPodError(resource, rawTurtleResult.message);
-
-    const dataset = rawTurtleResult;
-    const rootContainers = dataset.match(
-      null,
-      namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
-      namedNode("http://www.w3.org/ns/pim/space#Storage"),
-    );
-    const quads = rootContainers.toArray();
-    if (quads.length !== 1) {
-      return new NoncompliantPodError(
-        resource,
-        "There should be one storage listed in storage description resource.",
-      );
-    }
-    return new GetRootContainerFromStorageDescriptionSuccess(
-      resource,
-      quads[0].subject.value as SolidContainerUri,
     );
   } catch (e) {
     return UnexpectedResourceError.fromThrown(resource, e);

--- a/packages/connected-solid/src/requester/requests/getStorageDescription.ts
+++ b/packages/connected-solid/src/requester/requests/getStorageDescription.ts
@@ -1,0 +1,110 @@
+import { UnexpectedResourceError } from "@ldo/connected";
+import { namedNode } from "@ldo/rdf-utils";
+import { parse as parseLinkHeader } from "http-link-header";
+import type { SolidResource } from "../../resources/SolidResource";
+import type { SolidContainerUri, SolidLeafUri } from "../../types";
+import { guaranteeFetch } from "../../util/guaranteeFetch";
+import { rawTurtleToDataset } from "../../util/rdfUtils";
+import {
+  HttpErrorResult,
+  NotFoundHttpError,
+} from "../results/error/HttpErrorResult";
+import { NoncompliantPodError } from "../results/error/NoncompliantPodError";
+import {
+  GetRootContainerFromStorageDescriptionSuccess,
+  GetStorageDescriptionUriSuccess,
+} from "../results/success/StorageDescriptionSuccess";
+import type { BasicRequestOptions } from "./requestOptions";
+
+/**
+ * https://solidproject.org/TR/protocol#server-storage-description
+ */
+export async function getStorageDescriptionUris(
+  resource: SolidResource,
+  options?: BasicRequestOptions,
+) {
+  try {
+    const fetch = guaranteeFetch(options?.fetch);
+    const response = await fetch(resource.uri, { method: "HEAD" });
+    const httpErrorResult = HttpErrorResult.checkResponse(resource, response);
+    if (httpErrorResult) return httpErrorResult;
+    if (NotFoundHttpError.is(response)) {
+      return new NotFoundHttpError(
+        resource,
+        response,
+        "Could not get storage description of the resource because the resource does not exist.",
+      );
+    }
+
+    const linkHeader = response.headers.get("link");
+    if (!linkHeader) {
+      return new NoncompliantPodError(
+        resource,
+        "No link header present in request.",
+      );
+    }
+    const parsedLinkHeader = parseLinkHeader(linkHeader);
+    const storageDescriptionLinks = parsedLinkHeader.get(
+      "rel",
+      "http://www.w3.org/ns/solid/terms#storageDescription",
+    );
+
+    if (storageDescriptionLinks.length !== 1) {
+      return new NoncompliantPodError(
+        resource,
+        'There must be one link with a rel="http://www.w3.org/ns/solid/terms#storageDescription"',
+      );
+    }
+
+    return new GetStorageDescriptionUriSuccess(
+      resource,
+      storageDescriptionLinks[0].uri as SolidLeafUri,
+    );
+  } catch (e) {
+    return UnexpectedResourceError.fromThrown(resource, e);
+  }
+}
+
+export async function getRootContainerFromStorageDescription(
+  storageDescriptionUri: SolidLeafUri,
+  resource: SolidResource,
+  options?: BasicRequestOptions,
+) {
+  try {
+    const fetch = guaranteeFetch(options?.fetch);
+    const response = await fetch(storageDescriptionUri);
+    const errorResult = HttpErrorResult.checkResponse(resource, response);
+    if (errorResult) return errorResult;
+
+    if (response.status === 404) {
+      return new NoncompliantPodError(
+        resource,
+        "Storage description resource has not been found.",
+      );
+    }
+
+    const rawTurtle = await response.text();
+    const rawTurtleResult = await rawTurtleToDataset(rawTurtle, response.url);
+    if (rawTurtleResult instanceof Error)
+      return new NoncompliantPodError(resource, rawTurtleResult.message);
+    const dataset = rawTurtleResult;
+    const rootContainers = dataset.match(
+      null,
+      namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+      namedNode("http://www.w3.org/ns/pim/space#Storage"),
+    );
+    const quads = rootContainers.toArray();
+    if (quads.length !== 1) {
+      return new NoncompliantPodError(
+        resource,
+        "There should be one storage listed in storage description resource.",
+      );
+    }
+    return new GetRootContainerFromStorageDescriptionSuccess(
+      resource,
+      quads[0].subject.value as SolidContainerUri,
+    );
+  } catch (e) {
+    return UnexpectedResourceError.fromThrown(resource, e);
+  }
+}

--- a/packages/connected-solid/src/requester/requests/getStorageDescription.ts
+++ b/packages/connected-solid/src/requester/requests/getStorageDescription.ts
@@ -1,12 +1,12 @@
 import { UnexpectedResourceError } from "@ldo/connected";
 import { namedNode } from "@ldo/rdf-utils";
 import { parse as parseLinkHeader } from "http-link-header";
-import type { SolidResource } from "../../resources/SolidResource";
 import type { SolidContainerUri, SolidLeafUri } from "../../types";
 import { guaranteeFetch } from "../../util/guaranteeFetch";
 import { rawTurtleToDataset } from "../../util/rdfUtils";
 import {
   HttpErrorResult,
+  type HttpErrorResultType,
   NotFoundHttpError,
 } from "../results/error/HttpErrorResult";
 import { NoncompliantPodError } from "../results/error/NoncompliantPodError";
@@ -15,14 +15,36 @@ import {
   GetStorageDescriptionUriSuccess,
 } from "../results/success/StorageDescriptionSuccess";
 import type { BasicRequestOptions } from "./requestOptions";
+import type { SolidContainer } from "../../resources/SolidContainer.js";
+import type { SolidLeaf } from "../../resources/SolidLeaf.js";
+
+export type GetStorageDescriptionUriError<
+  ResourceType extends SolidContainer | SolidLeaf,
+> =
+  | HttpErrorResultType<ResourceType>
+  | NotFoundHttpError<ResourceType>
+  | NoncompliantPodError<ResourceType>
+  | UnexpectedResourceError<ResourceType>;
+export type GetStorageDescriptionUriResult<
+  ResourceType extends SolidContainer | SolidLeaf,
+> =
+  | GetStorageDescriptionUriSuccess
+  | GetStorageDescriptionUriError<ResourceType>;
 
 /**
+ * Get storage description URI from resource Link headers
+ *
+ * @param resource - Solid resource we start from
+ * @param options - Options object that may contain custom (authenticated) fetch
+ *
+ * @returns GetStorageDescriptionUriResult
+ *
  * https://solidproject.org/TR/protocol#server-storage-description
  */
-export async function getStorageDescriptionUris(
-  resource: SolidResource,
+export async function getStorageDescriptionUri(
+  resource: SolidLeaf | SolidContainer,
   options?: BasicRequestOptions,
-) {
+): Promise<GetStorageDescriptionUriResult<SolidLeaf | SolidContainer>> {
   try {
     const fetch = guaranteeFetch(options?.fetch);
     const response = await fetch(resource.uri, { method: "HEAD" });
@@ -65,12 +87,42 @@ export async function getStorageDescriptionUris(
   }
 }
 
-export async function getRootContainerFromStorageDescription(
+export type GetRootContainerFromStorageDescriptionError<
+  ResourceType extends SolidContainer | SolidLeaf,
+> =
+  | HttpErrorResultType<ResourceType>
+  | NoncompliantPodError<ResourceType>
+  | UnexpectedResourceError<ResourceType>;
+export type GetRootContainerFromStorageDescriptionResult<
+  ResourceType extends SolidContainer | SolidLeaf,
+> =
+  | GetRootContainerFromStorageDescriptionSuccess
+  | GetRootContainerFromStorageDescriptionError<ResourceType>;
+
+/**
+ * Fetches storage description by its URI, and extracts root container from it
+ * @param storageDescriptionUri - URI of storage description
+ * @param resource - The resource that initiated the root container discovery
+ * @param options - Options object with (authenticated) fetch function
+ *
+ * @returns GetRootContainerFromStorageDescriptionResult
+ *
+ * https://solidproject.org/TR/protocol#storage-description-rdf-type
+ */
+export async function getRootContainerByStorageDescriptionUri(
   storageDescriptionUri: SolidLeafUri,
-  resource: SolidResource,
+  resource: SolidLeaf | SolidContainer,
   options?: BasicRequestOptions,
-) {
+): Promise<
+  GetRootContainerFromStorageDescriptionResult<SolidLeaf | SolidContainer>
+> {
   try {
+    /**
+     * @TODO
+     * LDO could be used to fetch and/or process storage description resource
+     * Storage description is shared among pod resources. This dataset could be cached. (Where?)
+     * For fetching and caching, we would need a dataset. Could we use the resource's own dataset, or would it get polluted with this meta stuff?
+     */
     const fetch = guaranteeFetch(options?.fetch);
     const response = await fetch(storageDescriptionUri);
     const errorResult = HttpErrorResult.checkResponse(resource, response);
@@ -87,6 +139,7 @@ export async function getRootContainerFromStorageDescription(
     const rawTurtleResult = await rawTurtleToDataset(rawTurtle, response.url);
     if (rawTurtleResult instanceof Error)
       return new NoncompliantPodError(resource, rawTurtleResult.message);
+
     const dataset = rawTurtleResult;
     const rootContainers = dataset.match(
       null,

--- a/packages/connected-solid/src/requester/results/success/CheckRootContainerSuccess.ts
+++ b/packages/connected-solid/src/requester/results/success/CheckRootContainerSuccess.ts
@@ -19,7 +19,7 @@ export class CheckRootContainerSuccess extends ResourceSuccess<SolidContainer> {
 }
 
 /**
- * Indicates that the storage container has been successfully retireved from the
+ * Indicates that the storage container has been successfully retrieved from the
  * webId. Call `GetStorageContainerFromWebIdSuccess.storageContainers` for a
  * list of storage containers retrieved.
  */

--- a/packages/connected-solid/src/requester/results/success/StorageDescriptionSuccess.ts
+++ b/packages/connected-solid/src/requester/results/success/StorageDescriptionSuccess.ts
@@ -1,8 +1,5 @@
 import { ResourceSuccess } from "@ldo/connected";
-import type {
-  SolidContainerUri,
-  SolidLeafUri,
-} from "packages/connected-solid/src/types";
+import type { SolidLeafUri } from "packages/connected-solid/src/types";
 import type { SolidResource } from "../../../resources/SolidResource";
 
 export class GetStorageDescriptionUriSuccess extends ResourceSuccess<SolidResource> {
@@ -13,16 +10,5 @@ export class GetStorageDescriptionUriSuccess extends ResourceSuccess<SolidResour
   constructor(resource: SolidResource, storageDescriptionUri: SolidLeafUri) {
     super(resource);
     this.storageDescriptionUri = storageDescriptionUri;
-  }
-}
-
-export class GetRootContainerFromStorageDescriptionSuccess extends ResourceSuccess<SolidResource> {
-  type = "getStorageDescriptionUriSuccess" as const;
-
-  rootContainerUri: SolidContainerUri;
-
-  constructor(resource: SolidResource, rootContainerUri: SolidContainerUri) {
-    super(resource);
-    this.rootContainerUri = rootContainerUri;
   }
 }

--- a/packages/connected-solid/src/requester/results/success/StorageDescriptionSuccess.ts
+++ b/packages/connected-solid/src/requester/results/success/StorageDescriptionSuccess.ts
@@ -1,0 +1,28 @@
+import { ResourceSuccess } from "@ldo/connected";
+import type {
+  SolidContainerUri,
+  SolidLeafUri,
+} from "packages/connected-solid/src/types";
+import type { SolidResource } from "../../../resources/SolidResource";
+
+export class GetStorageDescriptionUriSuccess extends ResourceSuccess<SolidResource> {
+  type = "getStorageDescriptionUriSuccess" as const;
+
+  storageDescriptionUri: SolidLeafUri;
+
+  constructor(resource: SolidResource, storageDescriptionUri: SolidLeafUri) {
+    super(resource);
+    this.storageDescriptionUri = storageDescriptionUri;
+  }
+}
+
+export class GetRootContainerFromStorageDescriptionSuccess extends ResourceSuccess<SolidResource> {
+  type = "getStorageDescriptionUriSuccess" as const;
+
+  rootContainerUri: SolidContainerUri;
+
+  constructor(resource: SolidResource, rootContainerUri: SolidContainerUri) {
+    super(resource);
+    this.rootContainerUri = rootContainerUri;
+  }
+}

--- a/packages/connected-solid/src/resources/SolidContainer.ts
+++ b/packages/connected-solid/src/resources/SolidContainer.ts
@@ -227,6 +227,9 @@ export class SolidContainer extends SolidResource {
   /**
    * Gets the root container of this container. If this container is the root
    * container, this function returns itself.
+   *
+   * Consider getRootContainer() instead, which tries multiple discovery strategies.
+   *
    * @returns The root container for this container or undefined if there is no
    * root container.
    *

--- a/packages/connected-solid/src/resources/SolidContainer.ts
+++ b/packages/connected-solid/src/resources/SolidContainer.ts
@@ -236,14 +236,14 @@ export class SolidContainer extends SolidResource {
    * ```typescript
    * const container = ldoSolidDataset
    *   .getResource("https://example.com/container/");
-   * const rootContainer = await container.getRootContainer();
+   * const rootContainer = await container.getRootContainerByTraversal();
    * if (!rootContainer.isError) {
    *   // logs "https://example.com/"
    *   console.log(rootContainer.uri);
    * }
    * ```
    */
-  async getRootContainer(): Promise<
+  async getRootContainerByTraversal(): Promise<
     SolidContainer | CheckRootResultError | NoRootContainerError<SolidContainer>
   > {
     const parentContainerResult = await this.getParentContainer();
@@ -251,7 +251,7 @@ export class SolidContainer extends SolidResource {
     if (!parentContainerResult) {
       return this.isRootContainer() ? this : new NoRootContainerError(this);
     }
-    return parentContainerResult.getRootContainer();
+    return parentContainerResult.getRootContainerByTraversal();
   }
 
   /**

--- a/packages/connected-solid/src/resources/SolidLeaf.ts
+++ b/packages/connected-solid/src/resources/SolidLeaf.ts
@@ -321,21 +321,21 @@ export class SolidLeaf extends SolidResource {
    * ```typescript
    * const leaf = ldoSolidDataset
    *   .getResource("https://example.com/container/resource.ttl");
-   * const rootContainer = await leaf.getRootContainer();
+   * const rootContainer = await leaf.getRootContainerByTraversal();
    * if (!rootContainer.isError) {
    *   // logs "https://example.com/"
    *   console.log(rootContainer.uri);
    * }
    * ```
    */
-  async getRootContainer(): Promise<
+  async getRootContainerByTraversal(): Promise<
     SolidContainer | CheckRootResultError | NoRootContainerError<SolidContainer>
   > {
     // Check to see if this document has a pim:storage if so, use that
 
     // If not, traverse the tree
     const parent = await this.getParentContainer();
-    return parent.getRootContainer();
+    return parent.getRootContainerByTraversal();
   }
 
   /**

--- a/packages/connected-solid/src/resources/SolidResource.ts
+++ b/packages/connected-solid/src/resources/SolidResource.ts
@@ -48,11 +48,9 @@ import type { SolidNotificationMessage } from "../notifications/SolidNotificatio
 import type { CreateSuccess } from "../requester/results/success/CreateSuccess";
 import { GetWacUriSuccess } from "../wac/results/GetWacUriSuccess";
 import { GetWacRuleSuccess } from "../wac/results/GetWacRuleSuccess";
-import type { DatasetChanges } from "@ldo/rdf-utils";
+import { type DatasetChanges, namedNode } from "@ldo/rdf-utils";
 import type { UpdateResult } from "../requester/requests/updateDataResource";
 import {
-  getRootContainerByStorageDescriptionUri,
-  type GetRootContainerFromStorageDescriptionError,
   getStorageDescriptionUri,
   type GetStorageDescriptionUriError,
   type GetStorageDescriptionUriResult,
@@ -666,6 +664,8 @@ export abstract class SolidResource
    * Gets the root container from this resource's storage description
    * https://solidproject.org/TR/protocol#server-storage-description
    *
+   * Consider getRootContainer() instead, which tries multiple discovery strategies.
+   *
    * @param options - Options object
    * @param options.ignoreCache {boolean} - ignore cached storage resource URI and root container values
    *
@@ -674,12 +674,8 @@ export abstract class SolidResource
   async getRootContainerFromStorageDescription(options?: {
     ignoreCache: boolean;
   }): Promise<
-    | SolidContainer
-    | GetStorageDescriptionUriError<SolidContainer | SolidLeaf>
-    | GetRootContainerFromStorageDescriptionError<SolidContainer | SolidLeaf>
+    SolidContainer | GetStorageDescriptionUriError<SolidContainer | SolidLeaf>
   > {
-    const thisAsLeafOrContainer = this as unknown as SolidLeaf | SolidContainer;
-
     let rootContainerUri: SolidContainerUri;
 
     // Return the root container if it's already cached
@@ -692,15 +688,30 @@ export abstract class SolidResource
       if (storageDescriptionUriResult.isError)
         return storageDescriptionUriResult;
 
-      // Get root container from storage description URI
-      const result = await getRootContainerByStorageDescriptionUri(
+      // // Get root container from storage description URI
+      const storageDescriptionResource = this.context.dataset.getResource(
         storageDescriptionUriResult.storageDescriptionUri,
-        thisAsLeafOrContainer,
-        this.context.solid,
       );
+      const result = await storageDescriptionResource.readIfUnfetched();
       if (result.isError) return result;
-      this.rootContainerFromStorageDescriptionUri = result.rootContainerUri;
-      rootContainerUri = result.rootContainerUri;
+
+      const rootContainerQuads = this.context.dataset.match(
+        null,
+        namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+        namedNode("http://www.w3.org/ns/pim/space#Storage"),
+        namedNode(storageDescriptionUriResult.storageDescriptionUri),
+      );
+
+      // https://solidproject.org/TR/protocol#storage-description-statements
+      if (rootContainerQuads.size !== 1) {
+        return new NoncompliantPodError(
+          storageDescriptionResource, // storage description, or this resource?
+          "There should be one storage listed in storage description resource.",
+        );
+      }
+
+      rootContainerUri = rootContainerQuads.toArray()[0].subject
+        .value as SolidContainerUri;
     }
     const rootContainer = this.context.dataset.getResource(rootContainerUri);
     return rootContainer;

--- a/packages/connected-solid/src/resources/SolidResource.ts
+++ b/packages/connected-solid/src/resources/SolidResource.ts
@@ -51,9 +51,13 @@ import { GetWacRuleSuccess } from "../wac/results/GetWacRuleSuccess";
 import type { DatasetChanges } from "@ldo/rdf-utils";
 import type { UpdateResult } from "../requester/requests/updateDataResource";
 import {
-  getRootContainerFromStorageDescription,
-  getStorageDescriptionUris,
+  getRootContainerByStorageDescriptionUri,
+  type GetRootContainerFromStorageDescriptionError,
+  getStorageDescriptionUri,
+  type GetStorageDescriptionUriError,
+  type GetStorageDescriptionUriResult,
 } from "../requester/requests/getStorageDescription.js";
+import { GetStorageDescriptionUriSuccess } from "../requester/results/success/StorageDescriptionSuccess.js";
 
 /**
  * Statuses shared between both Leaf and Container
@@ -133,6 +137,22 @@ export abstract class SolidResource
    * Indicates that resources are not errors
    */
   public readonly isError: false = false as const;
+
+  /**
+   * @internal
+   * If a storage description URI was fetched, it is cached here
+   *
+   * https://solidproject.org/TR/protocol#server-storage-description
+   */
+  protected storageDescriptionUri?: SolidLeafUri;
+
+  /**
+   * @internal
+   * If a root container uri as fetched from storage description, it is cached here
+   *
+   * https://solidproject.org/TR/protocol#storage-description-statements
+   */
+  protected rootContainerFromStorageDescriptionUri?: SolidContainerUri;
 
   /**
    * @param context - SolidLdoDatasetContext for the parent dataset
@@ -577,6 +597,37 @@ export abstract class SolidResource
    */
 
   /**
+   * Retrieves the URI for the storage description of this resource
+   * @param options - set the "ignoreCache" field to true to ignore cached URI
+   * @returns results, containing SolidLeafUri when successful
+   *
+   * note: this is based on this.getWacUri method
+   */
+  protected async getStorageDescriptionUri(options?: {
+    ignoreCache: boolean;
+  }): Promise<GetStorageDescriptionUriResult<SolidLeaf | SolidContainer>> {
+    const thisAsLeafOrContainer = this as unknown as SolidLeaf | SolidContainer;
+    // Get the storage description if not already present
+    if (!options?.ignoreCache && this.storageDescriptionUri) {
+      return new GetStorageDescriptionUriSuccess(
+        thisAsLeafOrContainer,
+        this.storageDescriptionUri,
+      );
+    }
+
+    const storageDescriptionUriResult = await getStorageDescriptionUri(
+      thisAsLeafOrContainer,
+      { fetch: this.context.solid.fetch },
+    );
+    if (storageDescriptionUriResult.isError) {
+      return storageDescriptionUriResult;
+    }
+    this.storageDescriptionUri =
+      storageDescriptionUriResult.storageDescriptionUri;
+    return storageDescriptionUriResult;
+  }
+
+  /**
    * Gets the root container for this resource.
    * @returns The root container for this resource
    *
@@ -600,41 +651,72 @@ export abstract class SolidResource
   > {
     const result = await this.getRootContainerFromStorageDescription();
 
-    if (!result.isError) return result;
+    if (!result.isError) {
+      // some dependencies may assume that the root container has been fetched
+      // so we make sure it is, to avoid a breaking change
+      await result.readIfUnfetched();
+      return result;
+    }
 
     // if root container has not been found from storage description, fall back to traversal
     return await this.getRootContainerByTraversal();
   }
 
-  abstract getParentContainer(): Promise<
-    SolidContainer | CheckRootResultError | undefined
-  >;
+  /**
+   * Gets the root container from this resource's storage description
+   * https://solidproject.org/TR/protocol#server-storage-description
+   *
+   * @param options - Options object
+   * @param options.ignoreCache {boolean} - ignore cached storage resource URI and root container values
+   *
+   * @returns SolidContainer or error objects
+   */
+  async getRootContainerFromStorageDescription(options?: {
+    ignoreCache: boolean;
+  }): Promise<
+    | SolidContainer
+    | GetStorageDescriptionUriError<SolidContainer | SolidLeaf>
+    | GetRootContainerFromStorageDescriptionError<SolidContainer | SolidLeaf>
+  > {
+    const thisAsLeafOrContainer = this as unknown as SolidLeaf | SolidContainer;
 
-  async getRootContainerFromStorageDescription() {
-    const storageDescriptionResult = await getStorageDescriptionUris(
-      this,
-      this.context.solid,
-    );
-    if (storageDescriptionResult.isError) return storageDescriptionResult;
-    const result = await getRootContainerFromStorageDescription(
-      storageDescriptionResult.storageDescriptionUri,
-      this,
-      this.context.solid,
-    );
-    if (result.isError) return result;
+    let rootContainerUri: SolidContainerUri;
 
-    const rootContainer = this.context.dataset.getResource(
-      result.rootContainerUri,
-    );
-    // some dependencies assume that the root container has been fetched
-    await rootContainer.readIfUnfetched();
+    // Return the root container if it's already cached
+    if (!options?.ignoreCache && this.rootContainerFromStorageDescriptionUri) {
+      rootContainerUri = this.rootContainerFromStorageDescriptionUri;
+    } else {
+      // Get storage description URI
+      const storageDescriptionUriResult =
+        await this.getStorageDescriptionUri(options);
+      if (storageDescriptionUriResult.isError)
+        return storageDescriptionUriResult;
+
+      // Get root container from storage description URI
+      const result = await getRootContainerByStorageDescriptionUri(
+        storageDescriptionUriResult.storageDescriptionUri,
+        thisAsLeafOrContainer,
+        this.context.solid,
+      );
+      if (result.isError) return result;
+      this.rootContainerFromStorageDescriptionUri = result.rootContainerUri;
+      rootContainerUri = result.rootContainerUri;
+    }
+    const rootContainer = this.context.dataset.getResource(rootContainerUri);
     return rootContainer;
   }
 
+  /**
+   * https://solidproject.org/TR/protocol#client-storage-disovery
+   */
   abstract getRootContainerByTraversal(): Promise<
     | SolidContainer
     | CheckRootResultError
     | NoRootContainerError<SolidLeaf | SolidContainer>
+  >;
+
+  abstract getParentContainer(): Promise<
+    SolidContainer | CheckRootResultError | undefined
   >;
 
   /**

--- a/packages/connected-solid/src/resources/SolidResource.ts
+++ b/packages/connected-solid/src/resources/SolidResource.ts
@@ -50,6 +50,10 @@ import { GetWacUriSuccess } from "../wac/results/GetWacUriSuccess";
 import { GetWacRuleSuccess } from "../wac/results/GetWacRuleSuccess";
 import type { DatasetChanges } from "@ldo/rdf-utils";
 import type { UpdateResult } from "../requester/requests/updateDataResource";
+import {
+  getRootContainerFromStorageDescription,
+  getStorageDescriptionUris,
+} from "../requester/requests/getStorageDescription.js";
 
 /**
  * Statuses shared between both Leaf and Container
@@ -589,14 +593,48 @@ export abstract class SolidResource
    * }
    * ```
    */
-  abstract getRootContainer(): Promise<
+  async getRootContainer(): Promise<
     | SolidContainer
     | CheckRootResultError
     | NoRootContainerError<SolidLeaf | SolidContainer>
-  >;
+  > {
+    const result = await this.getRootContainerFromStorageDescription();
+
+    if (!result.isError) return result;
+
+    // if root container has not been found from storage description, fall back to traversal
+    return await this.getRootContainerByTraversal();
+  }
 
   abstract getParentContainer(): Promise<
     SolidContainer | CheckRootResultError | undefined
+  >;
+
+  async getRootContainerFromStorageDescription() {
+    const storageDescriptionResult = await getStorageDescriptionUris(
+      this,
+      this.context.solid,
+    );
+    if (storageDescriptionResult.isError) return storageDescriptionResult;
+    const result = await getRootContainerFromStorageDescription(
+      storageDescriptionResult.storageDescriptionUri,
+      this,
+      this.context.solid,
+    );
+    if (result.isError) return result;
+
+    const rootContainer = this.context.dataset.getResource(
+      result.rootContainerUri,
+    );
+    // some dependencies assume that the root container has been fetched
+    await rootContainer.readIfUnfetched();
+    return rootContainer;
+  }
+
+  abstract getRootContainerByTraversal(): Promise<
+    | SolidContainer
+    | CheckRootResultError
+    | NoRootContainerError<SolidLeaf | SolidContainer>
   >;
 
   /**

--- a/packages/connected-solid/test/Integration.test.ts
+++ b/packages/connected-solid/test/Integration.test.ts
@@ -576,7 +576,7 @@ describe("Integration", () => {
    */
   describe("rootContainer", () => {
     [SAMPLE2_BINARY_URI, SAMPLE_BINARY_URI].forEach((resourceUri) => {
-      it("Finds the root container", async () => {
+      it(`Finds the root container for ${resourceUri}`, async () => {
         const resource = solidLdoDataset.getResource(resourceUri);
         const result = await resource.getRootContainer();
         expect(result.type).toBe("SolidContainer");

--- a/packages/connected-solid/test/Integration.test.ts
+++ b/packages/connected-solid/test/Integration.test.ts
@@ -587,13 +587,27 @@ describe("Integration", () => {
     });
 
     describe("Root container from storage description", async () => {
-      it("Finds the root container", async () => {
+      async function testSuccess() {
         const resource = solidLdoDataset.getResource(SAMPLE_BINARY_URI);
         const result = await resource.getRootContainerFromStorageDescription();
         expect(result.type).toBe("SolidContainer");
         if (result.type !== "SolidContainer") return;
+        await result.readIfUnfetched();
         expect(result.uri).toBe(ROOT_CONTAINER);
         expect(result.isRootContainer()).toBe(true);
+      }
+
+      it("finds the root container", async () => {
+        await testSuccess();
+      });
+
+      it("caches the result", async () => {
+        s.fetchMock.mockClear();
+        await testSuccess();
+        expect(s.fetchMock).toHaveBeenCalled();
+        s.fetchMock.mockClear();
+        await testSuccess();
+        expect(s.fetchMock).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/connected-solid/test/Integration.test.ts
+++ b/packages/connected-solid/test/Integration.test.ts
@@ -587,12 +587,12 @@ describe("Integration", () => {
     });
 
     describe("Root container from storage description", async () => {
-      async function testSuccess() {
-        const resource = solidLdoDataset.getResource(SAMPLE_BINARY_URI);
+      async function testSuccess(resourceUri = SAMPLE_BINARY_URI) {
+        const resource = solidLdoDataset.getResource(resourceUri);
         const result = await resource.getRootContainerFromStorageDescription();
         expect(result.type).toBe("SolidContainer");
         if (result.type !== "SolidContainer") return;
-        await result.readIfUnfetched();
+        await result.read();
         expect(result.uri).toBe(ROOT_CONTAINER);
         expect(result.isRootContainer()).toBe(true);
       }
@@ -604,10 +604,26 @@ describe("Integration", () => {
       it("caches the result", async () => {
         s.fetchMock.mockClear();
         await testSuccess();
-        expect(s.fetchMock).toHaveBeenCalled();
+        expect(s.fetchMock).toHaveBeenCalledTimes(3);
         s.fetchMock.mockClear();
         await testSuccess();
-        expect(s.fetchMock).not.toHaveBeenCalled();
+        expect(s.fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      it("caches storage description resource", async () => {
+        // find a root container of first resource
+        s.fetchMock.mockClear();
+        expect(s.fetchMock.mock.calls).toHaveLength(0);
+        await testSuccess(SAMPLE_DATA_URI);
+        const callsUncached = s.fetchMock.mock.calls;
+
+        // find a root container of second resource within the same storage
+        s.fetchMock.mockClear();
+        expect(s.fetchMock.mock.calls).toHaveLength(0);
+        await testSuccess(SAMPLE_BINARY_URI);
+        const callsCached = s.fetchMock.mock.calls;
+        // now, one call should not happen
+        expect(callsCached.length).toEqual(callsUncached.length - 1);
       });
     });
 

--- a/packages/connected-solid/test/Integration.test.ts
+++ b/packages/connected-solid/test/Integration.test.ts
@@ -575,78 +575,102 @@ describe("Integration", () => {
    * Get Root Container
    */
   describe("rootContainer", () => {
-    it("Finds the root container", async () => {
-      const resource = solidLdoDataset.getResource(SAMPLE2_BINARY_URI);
-      const result = await resource.getRootContainer();
-      expect(result.type).toBe("SolidContainer");
-      if (result.type !== "SolidContainer") return;
-      expect(result.uri).toBe(ROOT_CONTAINER);
-      expect(result.isRootContainer()).toBe(true);
+    [SAMPLE2_BINARY_URI, SAMPLE_BINARY_URI].forEach((resourceUri) => {
+      it("Finds the root container", async () => {
+        const resource = solidLdoDataset.getResource(resourceUri);
+        const result = await resource.getRootContainer();
+        expect(result.type).toBe("SolidContainer");
+        if (result.type !== "SolidContainer") return;
+        expect(result.uri).toBe(ROOT_CONTAINER);
+        expect(result.isRootContainer()).toBe(true);
+      });
     });
 
-    it("Returns an error if there is no root container", async () => {
-      s.fetchMock.mockResolvedValueOnce(
-        new Response(TEST_CONTAINER_TTL, {
-          status: 200,
-          headers: new Headers({ "content-type": "text/turtle" }),
-        }),
-      );
-      s.fetchMock.mockResolvedValueOnce(
-        new Response(TEST_CONTAINER_TTL, {
-          status: 200,
-          headers: new Headers({ "content-type": "text/turtle" }),
-        }),
-      );
-      s.fetchMock.mockResolvedValueOnce(
-        new Response(TEST_CONTAINER_TTL, {
-          status: 200,
-          headers: new Headers({ "content-type": "text/turtle" }),
-        }),
-      );
-      const resource = solidLdoDataset.getResource(TEST_CONTAINER_URI);
-      const result = await resource.getRootContainer();
-      expect(result.isError).toBe(true);
-      if (!result.isError) return;
-      expect(result.type).toBe("noRootContainerError");
-      expect(result.message).toMatch(/\.* has not root container\./);
+    describe("Root container from storage description", async () => {
+      it("Finds the root container", async () => {
+        const resource = solidLdoDataset.getResource(SAMPLE_BINARY_URI);
+        const result = await resource.getRootContainerFromStorageDescription();
+        expect(result.type).toBe("SolidContainer");
+        if (result.type !== "SolidContainer") return;
+        expect(result.uri).toBe(ROOT_CONTAINER);
+        expect(result.isRootContainer()).toBe(true);
+      });
     });
 
-    it("An error to be returned if a common http error is encountered", async () => {
-      s.fetchMock.mockResolvedValueOnce(
-        new Response(TEST_CONTAINER_TTL, {
-          status: 500,
-        }),
-      );
-      const resource = solidLdoDataset.getResource(TEST_CONTAINER_URI);
-      const result = await resource.getRootContainer();
-      expect(result.isError).toBe(true);
-      expect(result.type).toBe("serverError");
-    });
+    describe("Root container by traversal", async () => {
+      it("Finds the root container", async () => {
+        const resource = solidLdoDataset.getResource(SAMPLE2_BINARY_URI);
+        const result = await resource.getRootContainerByTraversal();
+        expect(result.type).toBe("SolidContainer");
+        if (result.type !== "SolidContainer") return;
+        expect(result.uri).toBe(ROOT_CONTAINER);
+        expect(result.isRootContainer()).toBe(true);
+      });
 
-    it("Returns an UnexpectedResourceError if an unknown error is triggered", async () => {
-      s.fetchMock.mockRejectedValueOnce(new Error("Something happened."));
-      const resource = solidLdoDataset.getResource(TEST_CONTAINER_URI);
-      const result = await resource.getRootContainer();
-      expect(result.isError).toBe(true);
-      if (!result.isError) return;
-      expect(result.type).toBe("unexpectedResourceError");
-      expect(result.message).toBe("Something happened.");
-    });
-
-    it("returns a NonCompliantPodError when there is no root", async () => {
-      s.fetchMock.mockResolvedValueOnce(
-        new Response(TEST_CONTAINER_TTL, {
-          status: 200,
-          headers: new Headers({
-            "content-type": "text/turtle",
-            link: '<http://www.w3.org/ns/ldp#Resource>; rel="type"',
+      it("Returns an error if there is no root container", async () => {
+        s.fetchMock.mockResolvedValueOnce(
+          new Response(TEST_CONTAINER_TTL, {
+            status: 200,
+            headers: new Headers({ "content-type": "text/turtle" }),
           }),
-        }),
-      );
-      const resource = solidLdoDataset.getResource(ROOT_CONTAINER);
-      const result = await resource.getRootContainer();
-      expect(result.isError).toBe(true);
-      expect(result.type).toBe("noRootContainerError");
+        );
+        s.fetchMock.mockResolvedValueOnce(
+          new Response(TEST_CONTAINER_TTL, {
+            status: 200,
+            headers: new Headers({ "content-type": "text/turtle" }),
+          }),
+        );
+        s.fetchMock.mockResolvedValueOnce(
+          new Response(TEST_CONTAINER_TTL, {
+            status: 200,
+            headers: new Headers({ "content-type": "text/turtle" }),
+          }),
+        );
+        const resource = solidLdoDataset.getResource(TEST_CONTAINER_URI);
+        const result = await resource.getRootContainerByTraversal();
+        expect(result.isError).toBe(true);
+        if (!result.isError) return;
+        expect(result.type).toBe("noRootContainerError");
+        expect(result.message).toMatch(/\.* has not root container\./);
+      });
+
+      it("An error to be returned if a common http error is encountered", async () => {
+        s.fetchMock.mockResolvedValueOnce(
+          new Response(TEST_CONTAINER_TTL, {
+            status: 500,
+          }),
+        );
+        const resource = solidLdoDataset.getResource(TEST_CONTAINER_URI);
+        const result = await resource.getRootContainerByTraversal();
+        expect(result.isError).toBe(true);
+        expect(result.type).toBe("serverError");
+      });
+
+      it("Returns an UnexpectedResourceError if an unknown error is triggered", async () => {
+        s.fetchMock.mockRejectedValueOnce(new Error("Something happened."));
+        const resource = solidLdoDataset.getResource(TEST_CONTAINER_URI);
+        const result = await resource.getRootContainerByTraversal();
+        expect(result.isError).toBe(true);
+        if (!result.isError) return;
+        expect(result.type).toBe("unexpectedResourceError");
+        expect(result.message).toBe("Something happened.");
+      });
+
+      it("returns a NonCompliantPodError when there is no root", async () => {
+        s.fetchMock.mockResolvedValueOnce(
+          new Response(TEST_CONTAINER_TTL, {
+            status: 200,
+            headers: new Headers({
+              "content-type": "text/turtle",
+              link: '<http://www.w3.org/ns/ldp#Resource>; rel="type"',
+            }),
+          }),
+        );
+        const resource = solidLdoDataset.getResource(ROOT_CONTAINER);
+        const result = await resource.getRootContainerByTraversal();
+        expect(result.isError).toBe(true);
+        expect(result.type).toBe("noRootContainerError");
+      });
     });
   });
 
@@ -691,6 +715,7 @@ describe("Integration", () => {
     });
 
     it("Passes any errors returned from the getRootContainer method", async () => {
+      s.fetchMock.mockResolvedValueOnce(new Response(""));
       s.fetchMock.mockResolvedValueOnce(new Response(""));
       s.fetchMock.mockRejectedValueOnce(new Error("Something happened."));
       const result = await getStorageFromWebId(


### PR DESCRIPTION
Based on Solid protocol: https://solidproject.org/TR/protocol#server-storage-description-resource

`resource.getRootContainer()` tries to discover root storage from storage description resource. If that fails, it falls back to discovery by parent container traversal.

Also submethods have been added:
- `resource.getRootContainerByTraversal()` - the original method
- `resource.getRootContainerFromStorageDescription()` - the new feature

I recommend hiding whitespaces when reviewing (especially tests), because multiple tests have been nested into additional describe, otherwise unchanged.
<img width="233" height="301" alt="image" src="https://github.com/user-attachments/assets/8e7be9dc-a0e4-426d-9e7b-cc7c14b9ad07" />

TODO:

- [x] add comments
- [x] cache results?
- ...
- 
Fixes #17