### PR TITLE
Change tsconfig moduleResolution to "bundler"

### DIFF
--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "declaration": true,
     "declarationMap": true,
     "isolatedModules": true


### PR DESCRIPTION
This fixes a build issue after the switch to tsdown. Also build seems significantly faster.

`moduleResolution: bundler` is consistent with usage of tsdown bundler.

Full [example tsconfig.json](https://github.com/rolldown/tsdown-starter-stackblitz/blob/241a67502f2280b02ea5a0a4958088a144988e71/tsconfig.json) compatible with tsdown:

```json
{
  "compilerOptions": {
    "target": "esnext",
    "lib": ["es2023"],
    "moduleDetection": "force",
    "module": "preserve",
    "moduleResolution": "bundler",
    "resolveJsonModule": true,
    "types": [],
    "strict": true,
    "noUnusedLocals": true,
    "declaration": true,
    "esModuleInterop": true,
    "isolatedModules": true,
    "verbatimModuleSyntax": true,
    "skipLibCheck": true
  },
  "include": ["src", "tests"]
}
```

Fixes #144