### PR TITLE
Update session and ranInitialCheck synchronously

### DIFF
--- a/packages/solid-react/src/createBrowserSolidReactMethods.tsx
+++ b/packages/solid-react/src/createBrowserSolidReactMethods.tsx
@@ -39,21 +39,21 @@ export function createBrowserSolidReactMethods(
         window.localStorage.setItem(PRE_REDIRECT_URI, window.location.href);
       }
 
-      await handleIncomingRedirect({
+      const sessionInfo = await handleIncomingRedirect({
         restorePreviousSession: true,
       });
-      // Set timout to ensure this happens after the redirect
-      setTimeout(() => {
-        setSession({ ...getDefaultSession().info });
-        window.history.replaceState(
-          {},
-          "",
-          window.localStorage.getItem(PRE_REDIRECT_URI),
-        );
-        window.localStorage.removeItem(PRE_REDIRECT_URI);
 
-        setRanInitialAuthCheck(true);
-      }, 0);
+      if (!sessionInfo) return;
+
+      setSession(sessionInfo);
+      window.history.replaceState(
+        {},
+        "",
+        window.localStorage.getItem(PRE_REDIRECT_URI),
+      );
+      window.localStorage.removeItem(PRE_REDIRECT_URI);
+
+      setRanInitialAuthCheck(true);
     }, []);
 
     const login = useCallback(
@@ -69,7 +69,7 @@ export function createBrowserSolidReactMethods(
         };
         window.localStorage.setItem(PRE_REDIRECT_URI, window.location.href);
         await libraryLogin(fullOptions);
-        setSession({ ...getDefaultSession().info });
+        // user should be redirected away from the app
       },
       [],
     );

--- a/packages/solid-react/test/Auth-Integration.test.tsx
+++ b/packages/solid-react/test/Auth-Integration.test.tsx
@@ -1,0 +1,66 @@
+import React, { type FunctionComponent, useEffect } from "react";
+import { beforeEach, describe, it, vi, expect } from "vitest";
+import { useSolidAuth } from "../src/SolidAuthContext.js";
+import { render, waitFor } from "@testing-library/react";
+import { BrowserSolidLdoProvider } from "@ldo/solid-react";
+import { handleIncomingRedirect } from "@inrupt/solid-client-authn-browser";
+
+window.localStorage = {
+  length: 0,
+  getItem: () => null,
+  setItem: () => {},
+  clear: () => {},
+  removeItem: () => {},
+  key: () => null,
+};
+
+vi.mock("@inrupt/solid-client-authn-browser", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    handleIncomingRedirect: vi.fn(),
+  };
+});
+
+describe("Solid Auth Integration Tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // https://github.com/o-development/ldo/issues/52
+  it("keeps ranInitialAuthCheck and session.isLoggedIn in sync", async () => {
+    const renders: ReturnType<typeof useSolidAuth>[] = [];
+
+    vi.mocked(handleIncomingRedirect).mockResolvedValue({
+      isLoggedIn: true,
+      sessionId: "handle-incoming-redirect",
+    });
+
+    const TestComponent: FunctionComponent = () => {
+      const result = useSolidAuth();
+      useEffect(() => {
+        renders.push(result);
+      });
+      return null;
+    };
+
+    render(
+      <BrowserSolidLdoProvider>
+        <TestComponent />
+      </BrowserSolidLdoProvider>,
+    );
+
+    await waitFor(() => {
+      expect(renders.some((render) => render.session.isLoggedIn)).toBe(true);
+      expect(renders.some((render) => render.ranInitialAuthCheck)).toBe(true);
+    });
+
+    for (const renderData of renders) {
+      if (renderData.ranInitialAuthCheck === true) {
+        expect(renderData.session.isLoggedIn).toEqual(true);
+      } else {
+        expect(renderData.session.isLoggedIn).toEqual(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fixes #52

It was challenging to create a failing fixable test. A test covering the correct behavior has been created.

The issue and the fix have been tested in a minimal react app.

Possible follow-up (separate PR): Replace @inrupt/solid-client-authn-browser with https://www.npmjs.com/package/@uvdsl/solid-oidc-client-browser