### PR TITLE
Report unused eslint disable directives

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,5 +30,6 @@
         "caughtErrorsIgnorePattern": "^_"
       }
     ]
-  }
+  },
+  "reportUnusedDisableDirectives": true
 }

--- a/packages/connected-solid/src/getStorageFromWebId.ts
+++ b/packages/connected-solid/src/getStorageFromWebId.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ConnectedLdoDataset, ConnectedPlugin } from "@ldo/connected";
 import type { SolidContainerUri, SolidLeafUri } from "./types";
 import { GetStorageContainerFromWebIdSuccess } from "./requester/results/success/CheckRootContainerSuccess";

--- a/packages/type-traverser/src/transformer/Transformer.ts
+++ b/packages/type-traverser/src/transformer/Transformer.ts
@@ -34,7 +34,6 @@ import { InstanceGraph } from "../instanceGraph/InstanceGraph";
 // but if I ever feel so inclined, I should fix this in the future.
 
 export class Transformer<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Types extends TraverserTypes<any>,
   InputReturnTypes extends TransformerInputReturnTypes<Types>,
   Context = undefined,

--- a/packages/type-traverser/src/transformer/transformerSubTraversers/util/MultiMap.ts
+++ b/packages/type-traverser/src/transformer/transformerSubTraversers/util/MultiMap.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export class MultiMap<Key1, Key2, Value> {
   private map: Map<Key1, Map<Key2, Value>> = new Map();
-  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+
   private internalSize: number = 0;
 
   get(key1: Key1, key2: Key2): Value | undefined {

--- a/packages/type-traverser/src/transformer/transformerSubTraversers/util/MultiSet.ts
+++ b/packages/type-traverser/src/transformer/transformerSubTraversers/util/MultiSet.ts
@@ -4,7 +4,7 @@
 
 export class MultiSet<Key1, Key2> {
   private map: Map<Key1, Set<Key2>> = new Map();
-  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+
   private internalSize: number = 0;
 
   add(key1: Key1, key2: Key2): void {

--- a/packages/type-traverser/src/traverser/Traverser.ts
+++ b/packages/type-traverser/src/traverser/Traverser.ts
@@ -8,10 +8,7 @@ import type {
 import { Transformer, Visitor } from "../index";
 import type { TransformersInput } from "../transformer/Transformers";
 
-export class Traverser<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Types extends TraverserTypes<any>,
-> {
+export class Traverser<Types extends TraverserTypes<any>> {
   private traverserDefinition: TraverserDefinitions<Types>;
 
   constructor(traverserDefinition: TraverserDefinitions<Types>) {

--- a/packages/type-traverser/src/visitor/Visitor.ts
+++ b/packages/type-traverser/src/visitor/Visitor.ts
@@ -23,11 +23,7 @@ import { visitorParentSubTraverser } from "./visitorSubTraversers/VisitorParentS
 // TODO: Lots of "any" in this file. I'm just done with fancy typescript,
 // but if I ever feel so inclined, I should fix this in the future.
 
-export class Visitor<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Types extends TraverserTypes<any>,
-  Context = undefined,
-> {
+export class Visitor<Types extends TraverserTypes<any>, Context = undefined> {
   private traverserDefinition: TraverserDefinitions<Types>;
   private visitors: Visitors<Types, Context>;
 


### PR DESCRIPTION
This reports or fixes e.g. `// eslint-disable-next-line @typescript-eslint/no-explicit-any` when there is no `any`.

In other words, it tells us when we're using disable directives unnecessarily.