### PR TITLE
Gitignore test-solid-server data directories correctly

### DIFF
--- a/packages/test-solid-server/.gitignore
+++ b/packages/test-solid-server/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-*/data
+*/data*


### PR DESCRIPTION
Previously, a pattern for port was missing, so directories like `[base]/data3001/` were not ignored.